### PR TITLE
T34-about-help-contact

### DIFF
--- a/app/views/contact_form/_directions.html.erb
+++ b/app/views/contact_form/_directions.html.erb
@@ -1,0 +1,5 @@
+Please use the contact form to submit inquiries about <%=application_name %> in general, to report a problem you are experiencing with the system,
+to request assistance using <%=application_name %>; or to provide feedback.
+<br><br>
+See the <%= link_to "Help", "/help/" %> and <%= link_to "About", "/about/" %> pages for 
+additional information.

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,0 +1,69 @@
+<h2>About GW ScholarSpace</h2>
+<p>GW ScholarSpace is a repository for scholarly works at the George Washington University. It provides free, public access, broad visibility, and long-term preservation for scholarly works created by GW’s faculty, staff, and students, including Electronic Theses and Dissertations (ETDs).</p>
+<p>GW ScholarSpace runs on software developed by the GW Libraries <a href="https://library.gwu.edu/scholarly-technology">Scholarly Technology Group</a>. GW ScholarSpace is a <a href="https://library.gwu.edu/scholarly-technology">Ruby on Rails</a> based application that layers on top of <a href="http://sufia.io/">Sufia</a>, a <a href="http://projecthydra.org/">Hydra</a> application that incorporates features from <a href="http://projectblacklight.org/">Blacklight</a> and many other widely-used components. The repository's content and metadata is stored in a Fedora repository; <a href="http://sufia.io/">Fedora</a> is widely used, trusted, open-source repository software. GW ScholarSpace runs on GW and <a href="http://projectblacklight.org/">Washington Research Library Consortium</a> infrastructure.  All of the code for GW ScholarSpace (as well as Sufia) is open source and can be viewed in <a href="https://github.com/gwu-libraries/scholarspace-sufia7">GitHub</a>. GW ScholarSpace is under active development and users will benefit from new features and new integrations as they become available.</p>
+<h2>Using GW ScholarSpace to Participate in GW's Open Access Resolution</h2>
+<p>The <a href="http://library.gwu.edu/about/faculty-open-access">Open Access Resolution</a> applies to GW faculty scholarly works. It automatically gives GW a non-exclusive right to distribute designated GW scholarly works, unless an opt-out waiver has been signed (see Opting Out). When signing publishing agreements for the publication of an article, the author(s) should let the publisher know that the agreement is subject to prior license agreement with The George Washington University. The Author's Addendum can be found at Open Access at GW.</p>
+<p> As soon as an article is published, you will be able to upload a copy directly into the GW ScholarSpace repository. Currently, you can submit your work through our Deposit Form and the Library will notify you when the work has been uploaded.</p>
+<p> The Open Access Resolution does not apply to theses or dissertations.</p>
+<h2>Preservation</h2>
+<p>GW Libraries are committed to providing long-term access to all works submitted to GW ScholarSpace. Adhering to best practices, GW ScholarSpace and GW Libraries staff use digital preservation strategies that adapt to the changing technological environment.</p>
+<p>All work submitted to GW ScholarSpace will be preserved at a basic bit-level. The characteristics of a work (such as format, mime type, date created) will be captured and stored as metadata during the deposit process to mitigate potential format obsolescence. All works deposited will receive a SHA-1 (Secure Hash Algorithm) checksum, which is used to document file integrity over time. Regular file integrity checks will be performed to check for changes (such as file corruption), and can even be scheduled on-demand.</p>
+<p> Certain file formats (such as openly-documented, non-proprietary, lossless) are more easily preserved than others. To better assist contributors, please refer to the table below, which details recommended preservation file formats.</p>
+<h2 id="preservation-formats">Recommended Preservation Formats</h2>
+<p>Works using recommended preservation formats benefit from format longevity, acceptance and use in professional communities, long term accessibility of most viewing software, and incorporated metadata.</p>
+<p>The formats recommended below are recommended by the information technology, archival, and records management professional communities.</p>
+<p>
+<table border="1" width="496" cellspacing="5px" cellpadding="5px">
+<thead>
+<tr style="text-align: center;">
+<td style="padding: 7px;"><strong>Type</strong></td>
+<td style="padding: 7px;"><strong>Recommended Preservation Format</strong></td>
+<td style="padding: 7px;"><strong>File Extension</strong></td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="padding: 7px; text-align: center;">Text</td>
+<td style="padding: 7px;">PDF/A</td>
+<td style="padding: 7px; text-align: center;">.pdf</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Text</td>
+<td style="padding: 7px;">Plain Text</td>
+<td style="padding: 7px; text-align: center;">.txt</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Text</td>
+<td style="padding: 7px;">XML</td>
+<td style="padding: 7px; text-align: center;">.xml</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Text</td>
+<td style="padding: 7px;">CSV</td>
+<td style="padding: 7px; text-align: center;">.csv</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Image</td>
+<td style="padding: 7px;">JPEG</td>
+<td style="padding: 7px; text-align: center;">.jpg</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Image</td>
+<td style="padding: 7px;">TIFF</td>
+<td style="padding: 7px; text-align: center;">.tif</td>
+</tr>
+<tr>
+<td style="padding: 7px; text-align: center;">Audio</td>
+<td style="padding: 7px;">Wave</td>
+<td style="padding: 7px; text-align: center;">.wav</td>
+</tr>
+</tbody>
+</table>
+</p>
+<p>For more information about digital preservation best practices and standards, please see the <a href="http://www.loc.gov/preservation/resources/rfs/TOC.html">Library of Congress Recommended Formats Statement</a>.</p>
+<h2>Withdrawal</h2>
+<p>Works submitted to GW ScholarSpace are permanent. Under certain circumstances a work in GW ScholarSpace may be removed from view (for instance, if it’s due to a violation of the <a href="agreement">GW ScholarSpace Deposit Agreement</a>). To avoid loss of the historical record, all such instances will be documented via a statement attached to the record in PDF. The content of the document should be: <em>"This work has been withdrawn from GW ScholarSpace. If you have questions, please contact __________."</em></p>
+<h1>Related University Policies</h1>
+<p><a href="http://library.gwu.edu/about/faculty-open-access/">GW Faculty Open Access Resolution</a><br /> <a href="http://my.gwu.edu/files/policies/CopyrightPolicyFINAL.pdf">GW Copyright Policy</a> <br /><a href="http://my.gwu.edu/files/policies/PublicAccessNIHPublicationsPolicyFINAL.pdf">GW Public Access NIH Publications Policy</a> <br /><a href="http://my.gwu.edu/files/policies/RecordManagementFINAL.pdf">GW Records Management Policy</a> <br /><a href="http://ott.research.gwu.edu/gw-policies">GW Office of Technology Transfer Policies</a> <br /><a href="http://my.gwu.edu/files/policies/InformationSecurityPolicyFINAL.pdf">GW Information Security Policy</a></p>
+<p>&nbsp;</p>
+

--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -32,7 +32,7 @@
 <h4>What file formats are accepted in GW ScholarSpace?</h4>
 <p> GW ScholarSpace welcomes works in most digital formats; however, using recommended <a href="about#preservation-formats">preservation formats</a> will facilitate long-term preservation and usability.</p>
 <h4>What do I need to do before submitting my work to GW ScholarSpace?</h4>
-<p>You must read and agree to the Terms of Use and terms of the Deposit Agreement in order to submit your works. To submit theses and dissertations, please see http://library.gwu.edu/etd/submission-process 
+<p>You must read and agree to the <a href="terms">Terms of Use</a> and terms of the <a href="agreement">Deposit Agreement</a> in order to submit your works.</p>
 <h4>What is a Creative Commons license?</h4>
 <p>GW ScholarSpace allows copyright holders to apply specific creative commons licenses to their works. For more information on Creative Commons, please see the Creative Commons official website.</p>
 <h2 id="support">Support</h2>

--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -1,33 +1,40 @@
-<h2>Table of Contents</h2>
-<a href="#user-support"><i>User Support</i></a>
-<br />
-<a href="#browse"><i>Browse</i></a>
-<br />
-<a href="#search"><i>Search</i></a>
-<br />
-<a href="#deposit"><i>Deposit</i></a>
+<h2 id="deposit">Deposit</h2>
+<h4>How do I deposit my scholarly works?</h4>
+<p>To deposit your non-ETD works to GW ScholarSpace, please use the <a href="https://library.gwu.edu/scholarspace/submit/">GW ScholarSpace Deposit Form</a>.</p>
+<p>Electronic theses and dissertations also should not be submitted directly to GW ScholarSpace. The <a href="https://library.gwu.edu/etd">ETD site</a> provides information on depositing theses and dissertations.</p>
+<p>The form requires you to read and agree to the terms of the Deposit Agreement in order to submit your works. Once you have reviewed these terms, check the box and continue with the rest of the form.</p>
+<p> After submitting the form, you will receive an automatic email response confirmation to acknowledge that your works were successfully submitted. You will receive another notification email when your works become viewable in GW ScholarSpace.</p>
+<p> If you any questions about this process or are having problems, please <a href="contact">contact us</a>.</p>
+<h4>Which works may I contribute to GW ScholarSpace?</h4>
+<p>Works produced or sponsored by GW faculty, researchers, and staff may be shared through GW ScholarSpace, as well as student works sponsored by GW faculty or programs.</p>
+<h4>Which types of works are appropriate for GW ScholarSpace?</h4>
+<p> Appropriate types of work may include, but are not limited to theses and dissertations, journal pre-prints and post-prints, datasets, working papers, technical reports, conference papers, student works, annual reports, and newsletters.</p>
+<h4>Can I submit a student work other than a theses or dissertation?</h4>
+<p> Students wishing to submit Capstone papers, published articles, or other works to GW ScholarSpace must provide a written endorsement (emails accepted) from their faculty advisor or a faculty sponsor to openaccess@gwu.edu at the time of their submission. In the subject line of the email, please include: "GW ScholarSpace Faculty Endorsement".</p>
+<h4>What are the advantages of submitting my works to GW ScholarSpace?</h4>
+<ul>
+<li>Enduring links to each of your scholarly publications ensure long-term access.</li>
+<li>Enhanced exposure to Google Scholar and other search engines increases your works' visibility.</li>
+</ul>
+<h4>What is the maximum size of files that can be uploaded to GW ScholarSpace?</h4>
+<p>GW ScholarSpace has an upload size limit of 25 MB. If you would like to upload multiple files or a file larger than 25 MB, please send an email to scholarspace@gwu.edu.</p>
+<h4>Do I need to fill in all of the fields on the deposit form when submitting my work?</h4>
+<p>You, or a designated depositor, will need to fill in the required fields on the deposit form and accept the <a href="agreement">Deposit Agreement</a> before being able to submit your work.
+<p>Providing more information in the optional fields will increase the discoverability of your work within GW ScholarSpace.</p>
+<h4>Will the public be able to see my works?</h4>
+<p>Yes, GW ScholarSpace is intended for public access. However, if your publisher requires a temporary embargo, we can facilitate that (see <a href="http://library.gwu.edu/about/faculty-open-access">Open Access Resolution</a>).</p>
+<p>Embargoes for electronic theses and dissertations are handled separately; see the <a href="https://library.gwu.edu/etd">ETD site</a> for more information.</p>
 
-<h1 id="user-support">User Support</h1>
-<p>If you need to report a problem using GW ScholarSpace, or would like to request service assistance, consultation, or share feedback, please submit your issue via the <a href="contact">Contact Form</a>.</p>
+<p>Works deposited to GW ScholarSpace are publicly discoverable except where embargoed.</p>
+<h4>What kinds of materials should <em>not</em> be submitted to GW ScholarSpace?</h4>
+<p>GW ScholarSpace is not appropriate for works that include sensitive data such as personally identifiable information (PII) or protected health information (PHI).</p>
+<p>Electronic theses and dissertations also should not be submitted directly to GW ScholarSpace. The <a href="https://library.gwu.edu/etd">ETD site</a> provides information on depositing theses and dissertations.</p>
+<h4>What file formats are accepted in GW ScholarSpace?</h4>
+<p> GW ScholarSpace welcomes works in most digital formats; however, using recommended <a href="about#preservation-formats">preservation formats</a> will facilitate long-term preservation and usability.</p>
+<h4>What do I need to do before submitting my work to GW ScholarSpace?</h4>
+<p>You must read and agree to the Terms of Use and terms of the Deposit Agreement in order to submit your works. To submit theses and dissertations, please see http://library.gwu.edu/etd/submission-process 
+<h4>What is a Creative Commons license?</h4>
+<p>GW ScholarSpace allows copyright holders to apply specific creative commons licenses to their works. For more information on Creative Commons, please see the Creative Commons official website.</p>
+<h2 id="support">Support</h2>
+<p>If you need to report a problem using GW ScholarSpace, or would like to request assistance, consultation, or share feedback, please submit your issue via the <a href="contact">contact form</a>.</p>
 <p>System Maintenance Hours: To keep systems running at peak performance, and to ensure the best possible service, routine testing and maintenance are performed during the daily maintenance window from 5:00 a.m. to 7:00 a.m. EST/EDT. During this time, systems and services may be affected.</p>
-
-<h1 id="browse">Browse</h1>
-<p>From the main page of GW ScholarSpace you can browse using the <u>Browse the scholarly works of The George Washington University</u> link.</p>
-
-<h1 id="search">Search</h1>
-<p>GW ScholarSpace allows you to conduct a Basic or Advanced Search of its works.</p>
-
-<p>You may conduct a Basic Search using the search bar:</p>
-
-<p><%= image_tag 'searchbar.jpg' %>
-
-<p>Or, you may conduct an <a href="search">Advanced Search</a> using more specific criteria such as type of work, date created, GW affiliation, etc.  The Advanced Search page lists a number of search tips.
-
-<h1 id="deposit">Deposit</h1>
-<p>Please use the <a href="http://library.gwu.edu/scholarspace/submit">Deposit Form</a> to submit your works to GW Scholarspace.</p>
-
-<p>The form requires you to read and agree to the terms of the <a href="agreement">Deposit Agreement</a> in order to submit your works. Once you have reviewed these terms, check the box and continue with the rest of the form.</p>
-
-<p>After submitting the form, you will receive an automatic email response confirmation to acknowledge that your works were successfully submitted. You will receive another notification email when your works become viewable in GW ScholarSpace.</p>
-
-<p>If you any questions about this process or are having problems, please <a href="contact">contact us</a>.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,8 +87,6 @@ Rails.application.routes.draw do
   #     resources :products
   #   end
 
-  Hydra::BatchEdit.add_routes(self)
-  
   # Override Sufia about behavior so it's a static page, not a TinyMCE page
   # Note that this override must occur BEFORE mounting the Sufia engine routes.
   # Yes, that is somewhat counterintuitive.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,12 @@ Rails.application.routes.draw do
   #   end
 
   Hydra::BatchEdit.add_routes(self)
+  
+  # Override Sufia about behavior so it's a static page, not a TinyMCE page
+  # Note that this override must occur BEFORE mounting the Sufia engine routes.
+  # Yes, that is somewhat counterintuitive.
+  get 'about', controller: 'static', action: 'about', as: 'about'
+
   # This must be the very last route in the file because it has a catch-all route for 404 errors.
   # This behavior seems to show up only in production mode.
   mount Sufia::Engine => '/'


### PR DESCRIPTION
Rerouted about page to static pages controller. Override Sufia contact form directions erb with new local one. Replaced text with rewritten text/HTML for About, Help, and Contact pages. Fixes #34.