### PR TITLE
Update to stay in sync with sufia 7.2.0. Fixes #13

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -8,6 +8,6 @@
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted ) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim' ) %>
 <%= presenter.attribute_to_html(:based_near, render_as: :faceted ) %>
-<%= presenter.attribute_to_html(:related_url) %>
+<%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:bibliographic_citation) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted ) %>


### PR DESCRIPTION
The only visible difference here is the "link" icon, as links even within free-text metadata fields seem to render correctly as links.  However, this PR is worth doing to minimize divergence from the sufia code base; plus, it will pick up any enhancements to `:external_link`.