### PR TITLE
T22 Adds user roles and permissions for content admin role

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ end
 
 gem 'sufia', '7.2.0'
 
+gem 'hydra-role-management'
+
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap_form (2.5.2)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (0.10.5)
       bootstrap-sass
@@ -267,6 +268,10 @@ GEM
     hydra-pcdm (0.9.0)
       active-fedora (>= 10, < 12)
       mime-types (>= 1)
+    hydra-role-management (0.2.2)
+      blacklight
+      bootstrap_form
+      cancancan
     hydra-works (0.14.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
@@ -588,6 +593,7 @@ DEPENDENCIES
   devise-guests (~> 0.3)
   fcrepo_wrapper
   flipflop!
+  hydra-role-management
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.2.6)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CurationConcerns::Ability
   include Sufia::Ability
 
-  self.ability_logic += [:everyone_can_create_curation_concerns]
+  # self.ability_logic += [:everyone_can_create_curation_concerns]
 
   # Define any customized permissions here.
   def custom_permissions
@@ -13,6 +13,13 @@ class Ability
     # if current_user.admin?
     #   can [:destroy], ActiveFedora::Base
     # end
+    if current_user.admin?
+      can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+    end
+
+    if current_user.contentadmin?
+      can [:create, :edit, :update, :destroy], curation_concerns_models
+    end
 
     # Limits creating new objects to a specific group
     #
@@ -20,4 +27,15 @@ class Ability
     #   can [:create], ActiveFedora::Base
     # end
   end
+
+  private
+
+  def admin_user?
+    current_user.admin?
+  end
+
+  def contentadmin_user?
+    current_user.contentadmin?
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ActiveRecord::Base
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
+
   # Connects this user object to Curation Concerns behaviors.
   include CurationConcerns::User
   # Connects this user object to Sufia behaviors.
@@ -26,4 +30,9 @@ class User < ActiveRecord::Base
   def to_s
     email
   end
+
+  def contentadmin?
+    roles.where(name: 'content-admin').exists?
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   end
 
   devise_for :users
+  mount Hydra::RoleManagement::Engine => '/'
+
   mount CurationConcerns::Engine, at: '/'
   resources :welcome, only: 'index'
   root 'sufia/homepage#index'

--- a/db/migrate/20161204222308_user_roles.rb
+++ b/db/migrate/20161204222308_user_roles.rb
@@ -1,0 +1,18 @@
+class UserRoles < ActiveRecord::Migration
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, :id => false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, [:role_id, :user_id]
+    add_index :roles_users, [:user_id, :role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027140103) do
+ActiveRecord::Schema.define(version: 20161204222308) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -227,6 +227,18 @@ ActiveRecord::Schema.define(version: 20161027140103) do
 
   add_index "qa_local_authority_entries", ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
   add_index "qa_local_authority_entries", ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+  end
+
+  add_index "roles_users", ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+  add_index "roles_users", ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
 
   create_table "searches", force: :cascade do |t|
     t.binary   "query_params"


### PR DESCRIPTION
To test:

- Prerequisites:  Three registered users, one of whom will be an admin, one of whome will be a content admin, and one of whom will be none of the above.
- `bundle install`
- `rake db:migrate`
- If you don't have an admin user, create one at the rails console (see the [hydra-role-management wiki](https://github.com/projecthydra/sufia/wiki/Making-Admin-Users-in-Sufia) )
- Log in to the app as the admin user
- Verify that you can browse to /roles
- Create a new role called `content-admin` (exactly like that, with the dash)
- Add a different user to that role
- Log out.  Log in as the content admin user.  Verify that you can add (and edit and delete) new content
- Log out.  Log in as the "no special roles" user.  Verify that you can't add content.  In the current version, that means that when you press Share Your Work, the app will tell you don't have permissions.
- Log out.  Stay logged out.  Verify that when you press Share Your Work, the app will tell you don't have permissions and prompt you to log in.
